### PR TITLE
Fix native title bar background in light mode

### DIFF
--- a/src/app/root.scss
+++ b/src/app/root.scss
@@ -104,6 +104,11 @@ body,
 }
 
 body:not(.is-mobile) {
+  &:not(.is-translucent) {
+    --titlebar-background: var(--background-secondary);
+    --titlebar-background-focused: var(--background-secondary);
+  }
+
   --icon-xs: calc(14px + var(--icon-size-modifier));
   --icon-s: calc(16px + var(--icon-size-modifier));
   --icon-m: calc(16px + var(--icon-size-modifier));


### PR DESCRIPTION
## Summary

Give non-translucent desktop windows an opaque native title bar that matches `--background-secondary`.

This preserves Baseline's transparent title bar variables for translucent windows while preventing the macOS native title bar from exposing the black window surface in a light theme.

## Root cause

Baseline sets `--titlebar-background` and `--titlebar-background-focused` to `transparent` globally. The existing `.titlebar` background rule styles Obsidian's frameless title bar, but it does not provide an opaque background to the native title bar.

On macOS with Obsidian 1.13.2 and Baseline 3.2.11 in light mode, this produced dark title text on a black title bar.

## Validation

- Reproduced the issue on macOS with Obsidian 1.13.2 and Baseline 3.2.11.
- Applied the same variables as a vault snippet and visually verified that the title bar matches the light theme and its text is readable.
- Compiled `src/theme.scss` successfully with Dart Sass.
- Ran `git diff --check`.
